### PR TITLE
Propose last-minute bug fixes

### DIFF
--- a/airbnb/src/components/Listings/ListingAdd.js
+++ b/airbnb/src/components/Listings/ListingAdd.js
@@ -108,7 +108,7 @@ const Edit = props => {
       property_amenities: updatedValues.property_amenities,
       property_name: updatedValues.property_name,
       property_price: Number(updatedValues.property_price),
-      room_type: 2
+      room_type: Number(updatedValues.room_type)
     };
 
     // Sends the posted request to edit the listing ID, and then on successful completion, routes the user back to the listings page.

--- a/airbnb/src/components/Listings/ListingEdit.js
+++ b/airbnb/src/components/Listings/ListingEdit.js
@@ -115,7 +115,7 @@ const Edit = props => {
               label={"Property Type..."}
               type="text"
               name="room_type"
-              value={roomType}
+              defaultValue={props.listingData.room_type}
               onChange={roomTypeHandleChange}
               helperText={"Please select the type of property"}
             >
@@ -148,7 +148,7 @@ const Edit = props => {
               label={"Neighborhood Group..."}
               type="text"
               name="neighborhood_group"
-              value={neighborhoodGroup}
+              defaultValue={props.listingData.neighborhood_group}
               onChange={neighborhoodGroupHandleChange}
               helperText={"Please select your neighborhood group"}
             >
@@ -168,7 +168,7 @@ const Edit = props => {
               label={"Neighborhood..."}
               type="text"
               name="neighborhood"
-              value={neighborhood}
+              defaultValue={props.listingData.neighborhood}
               onChange={neighborhoodHandleChange}
               helperText={"Please select your neighborhood"}
             >

--- a/airbnb/src/components/NavBar.js
+++ b/airbnb/src/components/NavBar.js
@@ -72,7 +72,7 @@ const NavBar = props => {
       <Toolbar className={`${classes.navContainer} nav-container`}>
         <div className={classes.navTitle}>
           <h1 className={classes.logo}
-              onClick={sessionStorage.getItem("token") ? () => props.history.push("/listings") : () => props.history.push("/")}>Hostify</h1>
+              onClick={sessionStorage.getItem("token") ? () => window.location.href = "/listings" : () => props.history.push("/")}>Hostify</h1>
           {sessionStorage.getItem("token") ? <p>Welcome, {sessionStorage.getItem("username")}!</p> : null}
         </div>
         <nav className={classes.navBar}>


### PR DESCRIPTION
This pull request intends to fix 3 bugs I discovered with the frontend app.

**Bug 1: Blank screen when clicking logo while editing listing**

If the user is in the middle of editing a listing and clicks the Hostify logo on the top left, the screen blanks out, and the type error `e.listingData.map is not a function` appears on the JavaScript console.

The underlying issue seems to involve handling props across multiple pages with react-router. Since the logo runs `props.history.push("/listings")` on click, the props from the edit page are preserved since the web app as a whole did not refresh. But since the listings page has its own set of props, the web app probably becomes confused and throws the error.

(Forgive me if my explanation is wrong; I have little knowledge of React.)

Fortunately, it's possible to work around the issue by running `window.location.href = "/listings"` instead. This refreshes the web app, which resets the props and lets the listings page work again. Although not the most elegant solution, this change does not seem to hurt the web app responsiveness and is the easiest fix given the short time left on this assignment.

**Bug 2: Adding a listing always sets the room type to Private Room**

In ListingAdd.js, the object `fixedUpdatedValues` always sets the `room_type` to 2, or private room. Changing the sent room type to `updatedValues.room_type` fixes this problem.

**Bug 3: When editing a listing, the dropdown options don't default to the actual values.**

The dropdown options are the room type, neighborhood group, and neighborhood. Right now, they default to whatever the first value is on edit, which confuses the end user.

Editing the dropdown default values to whatever is listed in the props seems to resolve this problem. That said, this change means there's unused variables in `ListingEdit.js`, so verify this fix to ensure I didn't accidentally break anything else.